### PR TITLE
fix routify build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules/
 /public/build/
 /dist/
+/routify/
 
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "author": "Lucas Shanley <lpshanley@gmail.com>",
   "scripts": {
     "build": "rollup -c && electron-builder",
-	"dev": "routify -d -c dev:server",
-	"dev:server": "rollup -c -w",
+    "dev": "routify -d --routify-dir routify -c dev:server",
+    "dev:server": "rollup -c -w",
     "start": "cross-env NODE_ENV=development electron src/electron"
   },
   "build": {


### PR DESCRIPTION
This resolves the issues where it is looking for `index.html/index.svelte`